### PR TITLE
Switch the default client locale to German

### DIFF
--- a/roles/mattermost/templates/config.json.j2
+++ b/roles/mattermost/templates/config.json.j2
@@ -286,8 +286,8 @@
     },
     "LocalizationSettings": {
         "DefaultServerLocale": "en",
-        "DefaultClientLocale": "en",
-        "AvailableLocales": ""
+        "DefaultClientLocale": "de",
+        "AvailableLocales": "de,en,fr"
     },
     "SamlSettings": {
         "Enable": false,


### PR DESCRIPTION
The users are located in the German part of Switzerland and therefore expect the default client language to be set to "de".