### PR TITLE
Prod/proxysql

### DIFF
--- a/hosts-pt
+++ b/hosts-pt
@@ -16,5 +16,6 @@ galera-01 ansible_host=192.168.56.3
 galera-02 ansible_host=192.168.56.4
 galera-03 ansible_host=192.168.56.5
 
-[galera_bootstrap]
-galera-01 ansible_host=192.168.56.3
+[proxysql]
+proxysql-01 ansible_host=192.168.56.10
+proxysql-02 ansible_host=192.168.56.11

--- a/hosts-pt
+++ b/hosts-pt
@@ -1,5 +1,5 @@
 [mattermost]
-sax81106 
+sax81106
 
 [nextcloud]
 sax81108
@@ -10,3 +10,11 @@ sax81111
 
 [lool]
 sax81107
+
+[galera]
+galera-01 ansible_host=192.168.56.3
+galera-02 ansible_host=192.168.56.4
+galera-03 ansible_host=192.168.56.5
+
+[galera_bootstrap]
+galera-01 ansible_host=192.168.56.3

--- a/roles/galera/defaults/main.yml
+++ b/roles/galera/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+galera_mariadb_release: 10.3
+galera_cluster_name: b4k_galera_cluster
+galera_selinux_packages:
+  - libselinux-python
+  - policycoreutils-python
+galera_interface: eth0
+galera_interface_fact_var: ansible_{{ galera_interface }}

--- a/roles/galera/defaults/main.yml
+++ b/roles/galera/defaults/main.yml
@@ -1,8 +1,32 @@
 ---
+# version of mariadb/galera to use
 galera_mariadb_release: 10.3
-galera_cluster_name: b4k_galera_cluster
 galera_selinux_packages:
   - libselinux-python
   - policycoreutils-python
+# name of the galera cluster
+galera_cluster_name: b4k_galera_cluster
+# interface for mariadb connections
 galera_interface: eth0
 galera_interface_fact_var: ansible_{{ galera_interface }}
+# disable wsrep by default
+galera_wsrep: "OFF"
+# dat file holding galere node state
+galera_grastate_path: /var/lib/mysql/grastate.dat
+
+galera_root_password: root
+# proxysql monitoring user,
+# change according to "monitor_username" in proxysql.cnf
+galera_monitoring_user: muser
+# proxysql monitoring password,
+# change according to "monitor_password" in proxysql.cnf
+galera_monitoring_password: mpass
+# proxysql monitoring user host subnet,
+# should be the network from which proxysql monitors the galera nodes
+# for instance, '192.168.56.%' allows proxysql user 'muser'
+# monitoring access from host 192.168.56.10
+galera_monitoring_net: "192.168.56.%"
+# create user for app access through proxysql
+galera_app_user: app_root
+galera_app_password: app_root
+galera_app_net: "192.168.56.%"

--- a/roles/galera/tasks/configuration-galera-bootstrap.yml
+++ b/roles/galera/tasks/configuration-galera-bootstrap.yml
@@ -4,25 +4,31 @@
     name: mariadb
     state: stopped
   when: inventory_hostname == groups['galera'][0]
-  tags:
-    - 'role::galera_bootstrap'
 
-- name: set first node safe to bootstrap
+- name: register grastate path
+  stat:
+    path: "{{ galera_grastate_path }}"
+  register: galera_register_grastate
+
+- name: set first node safe to bootstrap if if wsrep was run previously
   lineinfile:
     dest: /var/lib/mysql/grastate.dat
     regexp: "^safe_to_bootstrap.*"
     line: "safe_to_bootstrap: 1"
+  when: inventory_hostname == groups['galera'][0] and galera_register_grastate.stat.exists == True
+
+- name: enable wsrep on all nodes
+  lineinfile:
+    dest: /etc/my.cnf.d/base4kids.cnf
+    regexp: "^wsrep_on.*"
+    line: "wsrep_on=ON"
 
 - name: bootstrap first galera node
   command: galera_new_cluster
   when: inventory_hostname == groups['galera'][0]
-  tags:
-    - 'role::galera_bootstrap'
 
 - name: restart the other galera nodes
   service:
     name: mariadb
     state: restarted
   when: inventory_hostname != groups['galera'][0]
-  tags:
-    - 'role::galera_bootstrap'

--- a/roles/galera/tasks/configuration-selinux.yml
+++ b/roles/galera/tasks/configuration-selinux.yml
@@ -1,0 +1,35 @@
+---
+- name: enable selinux
+  selinux:
+    policy: targeted
+    state: enforcing
+
+- name: reboot the machine to enable selinux
+  reboot:
+
+- name: wait for server to come back
+  become: false
+  local_action:
+    module: wait_for
+      host={{ ansible_host }}
+      port=22
+      delay=2
+      state=started
+
+- name: allow mariadb to listen on tcp ports
+  seport:
+    ports: 4567-4568,4444
+    proto: tcp
+    setype: mysqld_port_t
+    state: present
+
+- name: allow mariadb to listen on udp port
+  seport:
+    ports: 4567
+    proto: udp
+    setype: mysqld_port_t
+    state: present
+
+- selinux_permissive:
+    name: mysqld_t
+    permissive: true

--- a/roles/galera/tasks/configuration.yml
+++ b/roles/galera/tasks/configuration.yml
@@ -1,0 +1,15 @@
+---
+- name: add b4k mariadb config
+  template:
+    src: etc/my.cnf.d/base4kids.cnf.j2
+    dest: /etc/my.cnf.d/base4kids.cnf
+    owner: root
+    group: root
+    mode: 0644
+
+- include_tasks: configuration-selinux.yml
+
+- name: enable mariadb on boot
+  service:
+    name: "{{ galera_servicename }}"
+    enabled: yes

--- a/roles/galera/tasks/configuration.yml
+++ b/roles/galera/tasks/configuration.yml
@@ -9,7 +9,27 @@
 
 - include_tasks: configuration-selinux.yml
 
-- name: enable mariadb on boot
+- name: start and enable mariadb on boot
   service:
     name: "{{ galera_servicename }}"
     enabled: yes
+    state: started
+
+- include_tasks: secure-install.yml
+
+- name: create proxysql monitoring user
+  mysql_user:
+    name: "{{ galera_monitoring_user }}"
+    password: "{{ galera_monitoring_password }}"
+    host: "{{ galera_monitoring_net }}"
+    state: present
+
+- name: create proxysql app user
+  mysql_user:
+    name: "{{ galera_app_user }}"
+    password: "{{ galera_app_password }}"
+    host: "{{ galera_app_net }}"
+    priv: "*.*:ALL"
+    state: present
+
+- include_tasks: configuration-galera-bootstrap.yml

--- a/roles/galera/tasks/installation.yml
+++ b/roles/galera/tasks/installation.yml
@@ -1,0 +1,16 @@
+---
+- name: add mariadb repository to yum
+  template:
+    src: etc/yum.repos.d/mariadb.repo.j2
+    dest: /etc/yum.repos.d/mariadb.repo
+    owner: root
+    group: root
+    mode: 0644
+
+- name: install mariadb server packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ galera_selinux_packages }}"
+    - "{{ galera_packages }}"

--- a/roles/galera/tasks/main.yml
+++ b/roles/galera/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: include os specific vars
+  include_vars: '{{ item }}'
+  with_first_found:
+    - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
+    - '{{ ansible_os_family }}.yml'
+  tags:
+    - 'role::galera'
+    - 'role::galera:install'
+    - 'role::galera:config'
+
+- import_tasks: installation.yml
+  tags:
+    - 'role::galera'
+    - 'role::galera:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::galera'
+    - 'role::galera:config'

--- a/roles/galera/tasks/secure-install.yml
+++ b/roles/galera/tasks/secure-install.yml
@@ -1,0 +1,20 @@
+---
+- name: update mariadb root password for all root accounts
+  mysql_user:
+    name: root
+    password: "{{ galera_root_password }}"
+    check_implicit_admin: yes
+    state: present
+    host_all: yes
+
+- name: install .my.cnf for root
+  template: src=auth.my.cnf.j2 dest=~/.my.cnf
+
+- name: remove all anonymous user accounts
+  mysql_user:
+    name: ''
+    host_all: yes
+    state: absent
+
+- name: remove test db
+  mysql_db: name=test state=absent

--- a/roles/galera/templates/auth.my.cnf.j2
+++ b/roles/galera/templates/auth.my.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user = root
+password = {{ galera_root_password }}

--- a/roles/galera/templates/etc/my.cnf.d/base4kids.cnf.j2
+++ b/roles/galera/templates/etc/my.cnf.d/base4kids.cnf.j2
@@ -12,12 +12,12 @@ innodb_flush_log_at_trx_commit=0
 innodb_buffer_pool_size=122M
 wsrep_provider=/usr/lib64/galera/libgalera_smm.so
 
-# configure master-slave, not multi-master
+# configure flow control to perform better in master-slave scenario
 wsrep_provider_options="gcache.size=300M; gcache.page_size=300M; gcs.fc_limit = 256; gcs.fc_factor = 0.99; gcs.fc_master_slave = YES;"
 wsrep_cluster_name="{{ galera_cluster_name }}"
 wsrep_node_address="{{ hostvars[inventory_hostname][galera_interface_fact_var]['ipv4']['address'] }}"
 wsrep_cluster_address="gcomm://{{ groups['galera'] | map('extract', hostvars, [galera_interface_fact_var,'ipv4','address']) | list | join(',') }}"
-wsrep_on=ON
+wsrep_on={{ galera_wsrep }}
 
 [mysql_safe]
 log-error=/var/log/mysqld.log

--- a/roles/galera/templates/etc/my.cnf.d/base4kids.cnf.j2
+++ b/roles/galera/templates/etc/my.cnf.d/base4kids.cnf.j2
@@ -1,0 +1,24 @@
+# {{ ansible_managed }}
+
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+user=mysql
+binlog_format=ROW
+bind-address=0.0.0.0
+default_storage_engine=innodb
+innodb_autoinc_lock_mode=2
+innodb_flush_log_at_trx_commit=0
+innodb_buffer_pool_size=122M
+wsrep_provider=/usr/lib64/galera/libgalera_smm.so
+
+# configure master-slave, not multi-master
+wsrep_provider_options="gcache.size=300M; gcache.page_size=300M; gcs.fc_limit = 256; gcs.fc_factor = 0.99; gcs.fc_master_slave = YES;"
+wsrep_cluster_name="{{ galera_cluster_name }}"
+wsrep_node_address="{{ hostvars[inventory_hostname][galera_interface_fact_var]['ipv4']['address'] }}"
+wsrep_cluster_address="gcomm://{{ groups['galera'] | map('extract', hostvars, [galera_interface_fact_var,'ipv4','address']) | list | join(',') }}"
+wsrep_on=ON
+
+[mysql_safe]
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid

--- a/roles/galera/templates/etc/yum.repos.d/mariadb.repo.j2
+++ b/roles/galera/templates/etc/yum.repos.d/mariadb.repo.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+#
+# MariaDB 10.3 CentOS repository list
+# http://downloads.mariadb.org/mariadb/repositories/
+
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/{{ galera_mariadb_release }}/{{ galera_mariadb_host_arch }}
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1

--- a/roles/galera/vars/RedHat.yml
+++ b/roles/galera/vars/RedHat.yml
@@ -1,0 +1,6 @@
+---
+galera_packages:
+  - mariadb-server
+
+galera_servicename: mariadb
+galera_mariadb_host_arch: "centos7-amd64"

--- a/roles/galera/vars/RedHat.yml
+++ b/roles/galera/vars/RedHat.yml
@@ -1,6 +1,7 @@
 ---
 galera_packages:
   - mariadb-server
+  - MySQL-python
 
 galera_servicename: mariadb
 galera_mariadb_host_arch: "centos7-amd64"

--- a/roles/galera_bootstrap/tasks/main.yml
+++ b/roles/galera_bootstrap/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: stop mariadb on first galera node
+  service:
+    name: mariadb
+    state: stopped
+  when: inventory_hostname == groups['galera'][0]
+  tags:
+    - 'role::galera_bootstrap'
+
+- name: set first node safe to bootstrap
+  lineinfile:
+    dest: /var/lib/mysql/grastate.dat
+    regexp: "^safe_to_bootstrap.*"
+    line: "safe_to_bootstrap: 1"
+
+- name: bootstrap first galera node
+  command: galera_new_cluster
+  when: inventory_hostname == groups['galera'][0]
+  tags:
+    - 'role::galera_bootstrap'
+
+- name: restart the other galera nodes
+  service:
+    name: mariadb
+    state: restarted
+  when: inventory_hostname != groups['galera'][0]
+  tags:
+    - 'role::galera_bootstrap'

--- a/roles/proxysql/defaults/main.yml
+++ b/roles/proxysql/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+proxysql_mariadb_release: 10.3
+proxysql_mariadb_interface: eth0
+proxysql_mariadb_interface_fact_var: ansible_{{ proxysql_mariadb_interface }}
+proxysql_datadir: /var/lib/proxysql
+
+# user for the proxysql admin interface
+proxysql_admin_user: admin
+# password for the proxysql admin interface
+proxysql_admin_password: admin
+# port for the admin interface
+proxysql_admin_port: 6032
+
+# proxysql monitoring user on galera nodes
+# this user should exist on all registered galera hosts
+proxysql_monitoring_user: muser
+# proxysql monitoring password on galera nodes
+proxysql_monitoring_password: mpass
+
+# backend user for accesing the galera nodes
+proxysql_backend_user: app_root
+# backend password for accesing the galera nodes
+proxysql_backend_password: app_root
+
+# set this to True to reinit from config file, not loading proxysql.db
+proxysql_reinit_from_config_file: True

--- a/roles/proxysql/tasks/configuration.yml
+++ b/roles/proxysql/tasks/configuration.yml
@@ -1,0 +1,67 @@
+---
+- name: add proxysql config
+  template:
+    src: etc/proxysql.cnf.j2
+    dest: /etc/proxysql.cnf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: install .my.cnf for root
+  template: src=auth.my.cnf.j2 dest=~/.my.cnf
+
+- name: detect existing db
+  stat:
+    path: "{{ proxysql_datadir }}/proxysql.db"
+  register: proxysql_register_db
+
+- name: stop proxysql
+  service:
+    name: "{{ proxysql_servicename }}"
+    state: stopped
+
+- name: reinit if no config db or explicitly set
+  command: "service proxysql initial"
+  become: yes
+  when: proxysql_reinit_from_config_file or proxysql_register_db.stat.exists == False
+
+- name: start proxysql
+  service:
+    name: "{{ proxysql_servicename }}"
+    state: started
+
+# # load all settings from config file
+# - proxysql_manage_config:
+#     config_file="~/.my.cnf" action="LOAD" config_settings="MYSQL VARIABLES" direction="FROM" config_layer="CONFIG"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="LOAD" config_settings="MYSQL USERS" direction="FROM" config_layer="CONFIG"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="LOAD" config_settings="MYSQL SERVERS" direction="FROM" config_layer="CONFIG"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="LOAD" config_settings="MYSQL QUERY RULES" direction="FROM" config_layer="CONFIG"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="LOAD" config_settings="SCHEDULER" direction="FROM" config_layer="CONFIG"
+#
+# # persist all settings to db
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="SAVE" config_settings="MYSQL VARIABLES" direction="TO" config_layer="DISK"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="SAVE" config_settings="MYSQL USERS" direction="TO" config_layer="DISK"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="SAVE" config_settings="MYSQL SERVERS" direction="TO" config_layer="DISK"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="SAVE" config_settings="MYSQL QUERY RULES" direction="TO" config_layer="DISK"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="SAVE" config_settings="SCHEDULER" direction="TO" config_layer="DISK"
+#
+# # load all settings to runtime
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="LOAD" config_settings="MYSQL VARIABLES" direction="TO" config_layer="RUNTIME"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="LOAD" config_settings="MYSQL USERS" direction="TO" config_layer="RUNTIME"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="LOAD" config_settings="MYSQL SERVERS" direction="TO" config_layer="RUNTIME"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="LOAD" config_settings="MYSQL QUERY RULES" direction="TO" config_layer="RUNTIME"
+# - proxysql_manage_config:
+#     config_file=~/.my.cnf action="LOAD" config_settings="SCHEDULER" direction="TO" config_layer="RUNTIME"

--- a/roles/proxysql/tasks/installation-sysbench.yml
+++ b/roles/proxysql/tasks/installation-sysbench.yml
@@ -1,0 +1,12 @@
+---
+- name: download sysbench installer
+  get_url:
+    url: https://packagecloud.io/install/repositories/akopytov/sysbench/script.rpm.sh
+    dest: /tmp/script.rpm.sh
+    mode: 0755
+
+- name: enable the sysbench repo
+  shell: /tmp/script.rpm.sh
+
+- name: install sysbench
+  yum: name="sysbench" state="present"

--- a/roles/proxysql/tasks/installation.yml
+++ b/roles/proxysql/tasks/installation.yml
@@ -1,0 +1,32 @@
+---
+- name: add mariadb repository to yum
+  template:
+    src: etc/yum.repos.d/mariadb.repo.j2
+    dest: /etc/yum.repos.d/mariadb.repo
+    owner: root
+    group: root
+    mode: 0644
+
+- name: add proxysql repository to yum
+  template:
+    src: etc/yum.repos.d/proxysql.repo.j2
+    dest: /etc/yum.repos.d/proxysql.repo
+    owner: root
+    group: root
+    mode: 0644
+
+- name: install proxysql server packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ proxysql_packages }}"
+
+- name: enable and start proxysql on boot
+  service:
+    name: "{{ proxysql_servicename }}"
+    enabled: yes
+    state: started
+
+# install benchmark tool to test read/write split
+- include_tasks: installation-sysbench.yml

--- a/roles/proxysql/tasks/main.yml
+++ b/roles/proxysql/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- name: include os specific vars
+  include_vars: '{{ item }}'
+  with_first_found:
+    - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
+    - '{{ ansible_os_family }}.yml'
+  tags:
+    - 'role::proxysql'
+    - 'role::proxysql:install'
+    - 'role::proxysql:config'
+
+- import_tasks: installation.yml
+  tags:
+    - 'role::proxysql'
+    - 'role::proxysql:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::proxysql'
+    - 'role::proxysql:config'

--- a/roles/proxysql/templates/auth.my.cnf.j2
+++ b/roles/proxysql/templates/auth.my.cnf.j2
@@ -1,0 +1,5 @@
+[client]
+user = {{ proxysql_admin_user }}
+password = {{ proxysql_admin_password }}
+host = 127.0.0.1
+port = {{ proxysql_admin_port }}

--- a/roles/proxysql/templates/etc/proxysql.cnf.j2
+++ b/roles/proxysql/templates/etc/proxysql.cnf.j2
@@ -1,0 +1,156 @@
+# {{ ansible_managed }}
+
+datadir="{{ proxysql_datadir }}"
+
+admin_variables=
+{
+  admin_credentials="{{ proxysql_admin_user }}:{{ proxysql_admin_password }}"
+  mysql_ifaces="0.0.0.0:{{ proxysql_admin_port }}"
+#	debug=true
+}
+
+mysql_variables=
+{
+  threads=4
+  max_connections=2048
+  default_query_delay=0
+  default_query_timeout=36000000
+  have_compress=true
+  poll_timeout=2000
+  interfaces="0.0.0.0:6033"
+  default_schema="information_schema"
+  stacksize=1048576
+  server_version="5.5.30"
+  connect_timeout_server=3000
+  monitor_username="{{ proxysql_monitoring_user }}"
+  monitor_password="{{ proxysql_monitoring_password }}"
+  monitor_history=600000
+  monitor_connect_interval=60000
+  monitor_ping_interval=10000
+  monitor_read_only_interval=1500
+  monitor_read_only_timeout=500
+  ping_interval_server_msec=120000
+  ping_timeout_server=500
+  commands_stats=true
+  sessions_sort=true
+  connect_retries_on_failure=10
+}
+
+# defines replication hostgroups
+mysql_replication_hostgroups=
+(
+{
+  writer_hostgroup=1
+  reader_hostgroup=2
+  comment="b4k2_galera_cluster"
+}
+)
+
+# defines all the mariadb servers
+mysql_servers =
+(
+# the first galera node is configured as master (writes)
+# all following nodes of the galera cluster are slaves (reads only)
+# the "weight" is used to balance the load evenly between the slaves
+{% for host in groups['galera'] %}
+{% if loop.first %}
+{
+  address = "{{ hostvars[host]['ansible_host'] }}"
+  port = 3306
+  hostgroup = 1
+  weight = 100000
+  comment = "MASTER"
+}
+{% else %}
+,{
+  address = "{{ hostvars[host]['ansible_host'] }}"
+  port = 3306
+  hostgroup = 2
+  weight = 100000
+  comment = "SLAVE"
+}
+{% endif %}
+{% endfor %}
+,
+{% for host in groups['galera'] %}
+{% if loop.first %}
+{
+  address = "{{ hostvars[host]['ansible_host'] }}"
+  port = 3306
+  hostgroup = 2
+  weight = 1
+  comment = "MASTER"
+}
+{% else %}
+,{
+  address = "{{ hostvars[host]['ansible_host'] }}"
+  port = 3306
+  hostgroup = 1
+  weight = 1
+  comment = "SLAVE"
+}
+{% endif %}
+{% endfor %}
+)
+
+# defines all the mariadb users
+mysql_users:
+(
+{
+  username = "{{ proxysql_backend_user }}"
+  password = "{{ proxysql_backend_password }}"
+  default_hostgroup = 1
+  max_connections=1000
+  default_schema="information_schema"
+  active = 1
+}
+)
+
+# defines mariadb query rules
+# this is a very basic read/write splitting
+mysql_query_rules:
+(
+{
+  rule_id=1
+  active=1
+  match_pattern="^SELECT .* FOR UPDATE$"
+  destination_hostgroup=1
+  apply=1
+},
+{
+  rule_id=2
+  active=1
+  match_pattern="^SELECT"
+  destination_hostgroup=2
+  apply=1
+}
+)
+
+# the galera checker script monitors the state of the galera cluster
+# arg1: HOSTGROUP WRITERS (required)
+#       the hostgroup_id that contains nodes that will serve 'writes'
+# arg2: HOSTGROUP READERS (optional)
+#       the hostgroup_id that contains nodes that will serve 'reads'
+# arg3: NUMBER WRITERS (optional)
+#       maximum number of write hostgroup_id node that can be marked ONLINE
+#       when 0 (default), all nodes can be marked ONLINE
+# arg4: WRITERS ARE READERS (optional)
+#       when 1 (default), ONLINE nodes in write hostgroup_id will prefer
+#       not to be ONLINE in read hostgroup_id
+# arg5: LOG_FILE (optional)
+scheduler=
+(
+{
+  id=1
+  active=1
+  interval_ms=10000
+  filename="/usr/share/proxysql/tools/proxysql_galera_checker.sh"
+  arg1="1"
+  arg2="2"
+  # set number_writers=1, because Nextcloud requires inter-cluster isolation level
+  # READ-COMMITTED which is only guaranteed with a single-master (1 writer)
+  arg3="1"
+  arg4="1"
+  arg5="/var/lib/proxysql/proxysql_galera_checker.log"
+}
+)

--- a/roles/proxysql/templates/etc/yum.repos.d/mariadb.repo.j2
+++ b/roles/proxysql/templates/etc/yum.repos.d/mariadb.repo.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+#
+# MariaDB 10.3 CentOS repository list
+# http://downloads.mariadb.org/mariadb/repositories/
+
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/{{ proxysql_mariadb_release }}/{{ proxysql_mariadb_host_arch }}
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1

--- a/roles/proxysql/templates/etc/yum.repos.d/proxysql.repo.j2
+++ b/roles/proxysql/templates/etc/yum.repos.d/proxysql.repo.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+[proxysql_repo]
+name= ProxySQL YUM repository
+baseurl=http://repo.proxysql.com/ProxySQL/proxysql-1.4.x/centos/\$releasever
+gpgkey=http://repo.proxysql.com/ProxySQL/repo_pub_key
+gpgcheck=1

--- a/roles/proxysql/vars/RedHat.yml
+++ b/roles/proxysql/vars/RedHat.yml
@@ -1,0 +1,7 @@
+proxysql_packages:
+  - proxysql
+  - MariaDB-client
+  - MySQL-python
+
+proxysql_servicename: proxysql
+proxysql_mariadb_host_arch: centos7-amd64

--- a/site.yml
+++ b/site.yml
@@ -14,7 +14,7 @@
      - { role: php7, tags: php7 }
      - { role: nextcloud, tags: nextcloud }
 
-- hosts: ldap 
+- hosts: ldap
   roles:
      - { role: ldapuser, tags: ldapuser }
 
@@ -25,4 +25,7 @@
 - hosts: galera
   roles:
      - { role: galera, tags: galera }
-     - { role: galera_bootstrap, tags: galera_bootstrap }
+
+- hosts: proxysql
+  roles:
+     - { role: proxysql, tags: proxysql }

--- a/site.yml
+++ b/site.yml
@@ -1,3 +1,4 @@
+---
 - hosts: mattermost
   roles:
      - { role: epel, tags: epel }
@@ -21,3 +22,7 @@
   roles:
      - { role: lool, tags: lool }
 
+- hosts: galera
+  roles:
+     - { role: galera, tags: galera }
+     - { role: galera_bootstrap, tags: galera_bootstrap }


### PR DESCRIPTION
This pull request extends #11 with ProxySQL to provide automatic failover in single-master mode, thus, should make the Galera cluster safe for use with Nextcloud, because the READ-COMMITTED isolation level can be guaranteed across all (in this case 3) nodes.

Thank you for review.