### PR TITLE
keepalived for proxysql

### DIFF
--- a/hosts-pt
+++ b/hosts-pt
@@ -17,5 +17,5 @@ galera-02 ansible_host=192.168.56.4
 galera-03 ansible_host=192.168.56.5
 
 [proxysql]
-proxysql-01 ansible_host=192.168.56.10
+proxysql-01 keepalived_priority=150 ansible_host=192.168.56.10
 proxysql-02 ansible_host=192.168.56.11

--- a/roles/proxysql-keepalived/defaults/main.yml
+++ b/roles/proxysql-keepalived/defaults/main.yml
@@ -1,0 +1,12 @@
+keepalived_packages:
+  - keepalived
+
+# vip interface
+keepalived_interface: eth1
+# keepalived master/slave priority
+keepalived_priority: 100
+# keepalived virtual ips
+keepalived_vips:
+  - 172.28.128.20/24
+# keepalived auth password
+keepalived_password: 1111

--- a/roles/proxysql-keepalived/handlers/main.yml
+++ b/roles/proxysql-keepalived/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: keepalived reload
+  service:
+    name: keepalived
+    state: reloaded

--- a/roles/proxysql-keepalived/tasks/configuration.yml
+++ b/roles/proxysql-keepalived/tasks/configuration.yml
@@ -1,0 +1,16 @@
+---
+- name: allow bind on nonlocal ips
+  sysctl:
+    name: net.ipv4.ip_nonlocal_bind
+    value: 1
+    state: present
+
+- name: copy keepalived.conf
+  template:
+    src: etc/keepalived/keepalived.conf.j2
+    dest: /etc/keepalived/keepalived.conf
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
+  notify: keepalived reload

--- a/roles/proxysql-keepalived/tasks/installation.yml
+++ b/roles/proxysql-keepalived/tasks/installation.yml
@@ -1,0 +1,13 @@
+---
+- name: install keepalived server packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ keepalived_packages }}"
+
+- name: enable and start keepalived on boot
+  service:
+    name: keepalived
+    enabled: yes
+    state: started

--- a/roles/proxysql-keepalived/tasks/main.yml
+++ b/roles/proxysql-keepalived/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: include os specific vars
+  include_vars: '{{ item }}'
+
+  with_first_found:
+    - files:
+        - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
+        - '{{ ansible_os_family }}.yml'
+      skip: true
+  tags:
+    - 'role::keepalived'
+    - 'role::keepalived:install'
+    - 'role::keepalived:config'
+
+- import_tasks: installation.yml
+  tags:
+    - 'role::keepalived'
+    - 'role::keepalived:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::keepalived'
+    - 'role::keepalived:config'

--- a/roles/proxysql-keepalived/templates/etc/keepalived/keepalived.conf.j2
+++ b/roles/proxysql-keepalived/templates/etc/keepalived/keepalived.conf.j2
@@ -1,0 +1,44 @@
+# {{ ansible_managed }}
+# configuration file for keepalived
+
+vrr_script check_proxysql {
+  script "/bin/systemctl status proxysql"
+  interval 2
+  # any VRRP instance  monitoring the script will transition to the fault state
+  # after <fall> failures of the script. After that, <rise> consecutive successes
+  # will cause VRRP instances to leave the fault state.
+  fall 2
+  rise 2
+}
+
+vrrp_instance VI_1 {
+  state MASTER
+  interface {{ keepalived_interface }}
+  # arbitrary unique number from 0 to 255
+  # used to differentiate multiple instances of vrrpd
+  # running on the same NIC (and hence same socket).
+  virtual_router_id 51
+  # for electing MASTER, highest priority wins.
+  # to be MASTER, make this 50 more than on other machines.
+  priority {{ keepalived_priority }}
+  # VRRP Advert interval in seconds (e.g. 0.92) (use default)
+  advert_int 1
+  authentication {
+    auth_type PASS
+    # password for accessing vrrpd.
+    # should be the same on all machines.
+    # only the first eight (8) characters are used.
+    auth_pass {{ keepalived_password }}
+  }
+  # addresses add|del on change to MASTER, to BACKUP.
+  # with the same entries on other machines,
+  # the opposite transition will be occurring.
+  virtual_ipaddress {
+    {% for vip in keepalived_vips %}
+    {{ vip }}
+    {% endfor %}
+  }
+  track_script {
+    check_proxysql
+  }
+}

--- a/site.yml
+++ b/site.yml
@@ -29,3 +29,4 @@
 - hosts: proxysql
   roles:
      - { role: proxysql, tags: proxysql }
+     - { role: proxysql-keepalived, tags: proxysql-keepalived }


### PR DESCRIPTION
This `proxysql-keepalived` role extends #12 with a Keepalived configuration for IP failover of the ProxySQL instance(s).

Thank you for review.